### PR TITLE
Add missing fields - due date and fiscal id

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pg-ix-connector "0.1.0"
+(defproject pg-ix-connector "0.2.0"
   :description "Connects the payment gateway to InvoiceXpress"
   :url "https://github.com/weareswat/pg-ix-connector"
 

--- a/src/pg_ix_connector/core.clj
+++ b/src/pg_ix_connector/core.clj
@@ -6,10 +6,18 @@
             [request-utils.core :as request-utils]
             [result.core :as result]))
 
+(defn input-key
+  "Replace underscore for hyphen"
+  [key]
+  (let [key-string (name key)]
+    (if (clojure.string/includes? key-string "_")
+      (keyword (clojure.string/replace key-string "_" "-"))
+      key)))
+
 (defn optional-element
   "Only produce an element if the value exists"
   [document prop-key]
-  (if-let [prop-value (get document prop-key)]
+  (if-let [prop-value (get document (input-key prop-key))]
     (xml/element prop-key {} prop-value)))
 
 (defn document-xml
@@ -18,6 +26,7 @@
   (let [client (:client document)]
     (xml/element (keyword (:type document)) {}
                  (xml/element :date {} (:date document))
+                 (xml/element :due_date {} (:due-date document))
                  (optional-element document :sequence_number)
                  (optional-element document :sequence_id)
                  (optional-element document :reference)
@@ -25,6 +34,7 @@
                  (optional-element document :status)
                  (xml/element :client {}
                               (xml/element :name {} (:name client))
+                              (optional-element client :fiscal_id)
                               (optional-element client :email)
                               (optional-element client :country)
                               (optional-element client :postal_code)

--- a/test/pg_ix_connector/core_test.clj
+++ b/test/pg_ix_connector/core_test.clj
@@ -9,8 +9,10 @@
 (deftest document-xml-test
   (let [data {:type :invoice_receipt
               :date "07/05/2015"
+              :due-date "07/05/2015"
               :client {:name "Pedro"
-                       :code "123"}
+                       :code "123"
+                       :fiscal-id "999999990"}
               :items [{:name "Product"
                        :description "Beauty product"
                        :unit-price 5
@@ -19,8 +21,10 @@
         document-str (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                           "<invoice_receipt>"
                             "<date>07/05/2015</date>"
+                            "<due_date>07/05/2015</due_date>"
                             "<client>"
                               "<name>Pedro</name>"
+                              "<fiscal_id>999999990</fiscal_id>"
                               "<code>123</code>"
                             "</client>"
                             "<items type=\"array\">"


### PR DESCRIPTION
*Note: For optional xml keys we need to convert underscore to hyphen because the request sends the fields with hyphen but IX expect with underscore