### PR TITLE
Update client if requested

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pg-ix-connector "0.2.0"
+(defproject weareswat/pg-ix-connector "0.3.0"
   :description "Connects the payment gateway to InvoiceXpress"
   :url "https://github.com/weareswat/pg-ix-connector"
 


### PR DESCRIPTION
On IX sending updated client information on a document create request
does not update the client. To avoid doing it all the time, and also
to support a simple usage, we have a `:update-client` bool that if true
will make the update before creating the document.

Also changed the project name to include weareswat namespace (to
properly group it on clojars).

Ref: https://github.com/clanhr/mothership/issues/1741